### PR TITLE
install-tibia-maps: drop out-of-place break

### DIFF
--- a/install-tibia-maps
+++ b/install-tibia-maps
@@ -6,22 +6,18 @@ case "${1}" in
 	--grid)
 		echo 'Downloading & extracting `minimap-with-grid-overlay-and-markers.zip`…';
 		url='https://tibiamaps.io/downloads/minimap-with-grid-overlay-and-markers';
-		break;
 		;;
 	--grid-no-markers)
 		echo 'Downloading & extracting `minimap-with-grid-overlay-without-markers.zip`…';
 		url='https://tibiamaps.io/downloads/minimap-with-grid-overlay-without-markers';
-		break;
 		;;
 	--no-markers)
 		echo 'Downloading & extracting `minimap-without-markers.zip`…';
 		url='https://tibiamaps.io/downloads/minimap-without-markers';
-		break;
 		;;
 	*)
 		echo 'Downloading & extracting `minimap-with-markers.zip`…';
 		url='https://tibiamaps.io/downloads/minimap-with-markers';
-		break;
 		;;
 esac;
 zip_file_name="$(mktemp)";


### PR DESCRIPTION
The `break` shell builtin does not terminate `case` branches unlike in C
and at least GNU bash v5.1.8 warns about it:
```
  break: only meaningful in a `for', `while', or `until' loop
```
Instead `case` branches are terminated by double semicolon, which we
already use, so drop the useless `break`.