### PR TITLE
Use XDG base directory to search for Tibia files

### DIFF
--- a/install-tibia-maps
+++ b/install-tibia-maps
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-TIBIA_DIR="${HOME}/.local/share/CipSoft GmbH/Tibia/packages/Tibia";
+TIBIA_DIR="${XDG_DATA_HOME:-"${HOME}/.local/share"}/CipSoft GmbH/Tibia/packages/Tibia";
 mkdir -p "${TIBIA_DIR}";
 case "${1}" in
 	--grid)


### PR DESCRIPTION
The Tibia Linux client currently follows [XDG base directory specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) to place its files. This means that, if `$XDG_DATA_HOME` is set to something other than `"$HOME/.local/share"`, then `install-tibia-maps` would be unable to find it.

Fixes the path so that it points to the correct directory, falling back to the previous default location if `$XDG_DATA_HOME` is unset.